### PR TITLE
Fixed playback order when playing album

### DIFF
--- a/js/app/controllers/playercontroller.js
+++ b/js/app/controllers/playercontroller.js
@@ -39,6 +39,34 @@ angular.module('Music').controller('PlayerController',
 		total: 0
 	};
 
+	$scope.player.on('buffer', function (percent) {
+		$scope.setBufferPercentage(parseInt(percent));
+		$scope.$digest();
+	});
+	$scope.player.on('ready', function () {
+		$scope.setLoading(false);
+		$scope.$digest();
+	});
+	$scope.player.on('progress', function (currentTime) {
+		$scope.setTime(currentTime/1000, $scope.player.duration/1000);
+		$scope.$digest();
+	});
+	$scope.player.on('end', function() {
+		$scope.setPlay(false);
+		$scope.$digest();
+		if($scope.$$phase) {
+			$scope.next();
+		} else {
+			$scope.$apply(function(){
+				$scope.next();
+			});
+		}
+	});
+	$scope.player.on('duration', function(msecs) {
+		$scope.setTime($scope.position.current, $scope.player.duration/1000);
+		$scope.$digest();
+	});
+
 	// display a play icon in the title if a song is playing
 	$scope.$watch('playing', function(newValue) {
 		var title = $('title').html().trim();
@@ -83,40 +111,13 @@ angular.module('Music').controller('PlayerController',
 											return album.id === newValue.albumId;
 										});
 
-			$scope.player=Audio.fromURL($scope.getPlayableFileURL($scope.currentTrack));
+			$scope.player.fromURL($scope.getPlayableFileURL($scope.currentTrack));
 			$scope.setLoading(true);
 
 			$scope.player.play();
 
 			$scope.setPlay(true);
 
-			$scope.player.on('buffer', function (percent) {
-				$scope.setBufferPercentage(parseInt(percent));
-				$scope.$digest();
-			});
-			$scope.player.on('ready', function () {
-				$scope.setLoading(false);
-				$scope.$digest();
-			});
-			$scope.player.on('progress', function (currentTime) {
-				$scope.setTime(currentTime/1000, $scope.player.duration/1000);
-				$scope.$digest();
-			});
-			$scope.player.on('end', function() {
-				$scope.setPlay(false);
-				$scope.$digest();
-				if($scope.$$phase) {
-					$scope.next();
-				} else {
-					$scope.$apply(function(){
-						$scope.next();
-					});
-				}
-			});
-			$scope.player.on('duration', function(msecs) {
-				$scope.setTime($scope.position.current, $scope.player.duration/1000);
-				$scope.$digest();
-			});
 		} else {
 			$scope.currentArtist = null;
 			$scope.currentAlbum = null;

--- a/js/app/playerwrapper.js
+++ b/js/app/playerwrapper.js
@@ -122,5 +122,4 @@ PlayerWrapper.prototype.fromURL = function(typeAndURL) {
 			});
 			break;
 	}
-	return this;
 };

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -335,6 +335,34 @@ angular.module('Music').controller('PlayerController',
 		total: 0
 	};
 
+	$scope.player.on('buffer', function (percent) {
+		$scope.setBufferPercentage(parseInt(percent));
+		$scope.$digest();
+	});
+	$scope.player.on('ready', function () {
+		$scope.setLoading(false);
+		$scope.$digest();
+	});
+	$scope.player.on('progress', function (currentTime) {
+		$scope.setTime(currentTime/1000, $scope.player.duration/1000);
+		$scope.$digest();
+	});
+	$scope.player.on('end', function() {
+		$scope.setPlay(false);
+		$scope.$digest();
+		if($scope.$$phase) {
+			$scope.next();
+		} else {
+			$scope.$apply(function(){
+				$scope.next();
+			});
+		}
+	});
+	$scope.player.on('duration', function(msecs) {
+		$scope.setTime($scope.position.current, $scope.player.duration/1000);
+		$scope.$digest();
+	});
+
 	// display a play icon in the title if a song is playing
 	$scope.$watch('playing', function(newValue) {
 		var title = $('title').html().trim();
@@ -379,40 +407,13 @@ angular.module('Music').controller('PlayerController',
 											return album.id === newValue.albumId;
 										});
 
-			$scope.player=Audio.fromURL($scope.getPlayableFileURL($scope.currentTrack));
+			$scope.player.fromURL($scope.getPlayableFileURL($scope.currentTrack));
 			$scope.setLoading(true);
 
 			$scope.player.play();
 
 			$scope.setPlay(true);
 
-			$scope.player.on('buffer', function (percent) {
-				$scope.setBufferPercentage(parseInt(percent));
-				$scope.$digest();
-			});
-			$scope.player.on('ready', function () {
-				$scope.setLoading(false);
-				$scope.$digest();
-			});
-			$scope.player.on('progress', function (currentTime) {
-				$scope.setTime(currentTime/1000, $scope.player.duration/1000);
-				$scope.$digest();
-			});
-			$scope.player.on('end', function() {
-				$scope.setPlay(false);
-				$scope.$digest();
-				if($scope.$$phase) {
-					$scope.next();
-				} else {
-					$scope.$apply(function(){
-						$scope.next();
-					});
-				}
-			});
-			$scope.player.on('duration', function(msecs) {
-				$scope.setTime($scope.position.current, $scope.player.duration/1000);
-				$scope.$digest();
-			});
 		} else {
 			$scope.currentArtist = null;
 			$scope.currentAlbum = null;


### PR DESCRIPTION
The playback order of tracks within an album was odd, to say the least. Tracks were being skipped over and sometimes the same track could be played many times, and all this while neither Shuffle nor Repeat was active. The problem was not visible when manually changing to next or previous track with the buttons, but only when the tracks were actually played through and the next track was started automatically.

The bug was caused by registering the same callbacks again and again for the same PlayerWrapper instance every time when the playing song changed. Hence, the $scope.next() function got called many times when the track ended.
