### PR TITLE
Fix repeat icon AngularJS template interpolation with ng-src

### DIFF
--- a/templates/partials/controls.php
+++ b/templates/partials/controls.php
@@ -71,7 +71,7 @@
 	<img id="shuffle" class="control toggle small svg" alt="{{ 'Shuffle' | translate }}" title="{{ shuffleTooltip() }}"
 		src="<?php HtmlUtil::printSvgPath('shuffle') ?>" ng-class="{active: shuffle}" ng-click="toggleShuffle()" />
 	<img id="repeat" class="control toggle small svg" alt="{{ 'Repeat' | translate }}" title="{{ repeatTooltip() }}"
-		ng-src="{{ repeat === 'one' ? '<?php HtmlUtil::printSvgPath('repeat-1') ?>' : '<?php HtmlUtil::printSvgPath('repeat') ?>' }}"
+		ng-src="{{ repeat === 'one' ? '<?php echo HtmlUtil::getSvgPath('repeat-1') ?>' : '<?php echo HtmlUtil::getSvgPath('repeat') ?>' }}"
 		ng-class="{active: repeat != 'false' }" ng-click="toggleRepeat()" />
 
 	<volume-control player="player">


### PR DESCRIPTION
Using src with inline PHP printSvgPath() inside an AngularJS template interpolation string caused invalid relative URL parsing and blank page errors on Nextcloud. Converted to ng-src with HtmlUtil::getSvgPath().